### PR TITLE
Support binary files via `digest_file`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,8 @@ pub fn digest_bytes(input: &[u8]) -> String {
 /// ```
 ///
 pub fn digest_file<P: AsRef<Path>>(path: P) -> Result<String, io::Error> {
-    let buf = fs::read_to_string(path)?;
-    Ok(__digest__(&buf.as_bytes()))
+    let bytes = fs::read(path)?;
+    Ok(__digest__(&bytes()))
 }
 
 fn __digest__(data: &[u8]) -> String {


### PR DESCRIPTION
By reading into a `String` and then calling `as_bytes()`, `digest_file` will error if given a file containing non-UTF-8 data.
This change skips the intermediate `String` and reads straight to a `Vec<u8>`, allowing binary files to be hashed