### PR TITLE
Implement `Sha256Digest` for `Vec<u8>` and `&Vec<u8>`and `&String` directly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,18 @@ impl Sha256Digest for &[u8] {
     }
 }
 
+impl Sha256Digest for &Vec<u8> {
+    fn digest(self) -> String {
+        __digest__(self)
+    }
+}
+
+impl Sha256Digest for Vec<u8> {
+    fn digest(self) -> String {
+        __digest__(&self)
+    }
+}
+
 impl Sha256Digest for String {
     fn digest(self) -> String {
         __digest__(self.as_bytes())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,12 @@ impl Sha256Digest for &str {
     }
 }
 
+impl Sha256Digest for &String {
+    fn digest(self) -> String {
+        __digest__(self.as_bytes())
+    }
+}
+
 impl TrySha256Digest for &Path {
     type Error = io::Error;
     fn digest(self) -> Result<String, Self::Error> {


### PR DESCRIPTION
Previously, this didn't compile:
````
let input: Vec<u8> = b"some owned bytes".to_vec();
sha256::digest(input);
````
and the error message was pretty unhelpful:
````
error[E0277]: the trait bound `Vec<u8>: Sha256Digest` is not satisfied
  --> examples/knampf.rs:6:20
   |
6  |     sha256::digest(input);
   |     -------------- ^^^^^ the trait `Sha256Digest` is not implemented for `Vec<u8>`
   |     |
   |     required by a bound introduced by this call
   |
   = help: the following other types implement trait `Sha256Digest`:
             &[u8; N]
             &[u8]
             &str
             String
note: required by a bound in `sha256::digest`
  --> /home/level3/Documents/Rust/sha256-rs/src/lib.rs:48:18
   |
48 | pub fn digest<D: Sha256Digest>(input: D) -> String {
   |                  ^^^^^^^^^^^^ required by this bound in `digest`
````

The solution is to do a reborrow: `sha256::digest(&*input);` 
But getting to that took a while and me and my colleges didn't understand what was happening. Apparently the `Deref` mechanism that lets you usually use `&Vec<u8>` in place of `&[u8]` doesn't work with the `Sha256Digest` trait.

So in this PR, I implement Sha256Digest for `Vec<u8>` and `&Vec<u8>` directly. This makes the first example just work.

The situation is similar with `&String`, which usually works the same as `&str`, but not here. So I added an impl for that too.